### PR TITLE
Adding ArtifactHub entries for HTTP Addon v0.2.0

### DIFF
--- a/artifacthub/add-ons-http/0.2.0/README.md
+++ b/artifacthub/add-ons-http/0.2.0/README.md
@@ -1,0 +1,11 @@
+<p align="center"><img src="https://github.com/kedacore/keda/raw/main/images/logos/keda-word-colour.png" width="300"/></p>
+
+<p style="font-size: 25px" align="center"><b>Kubernetes-based Event Driven Autoscaling - HTTP Add-On</b></p>
+<p style="font-size: 25px" align="center">
+
+The KEDA HTTP Add On allows Kubernetes users to automatically scale their HTTP servers up and down (including to/from zero) based on incoming HTTP traffic. Please see the [HTTP Addon repository](https://github.com/kedacore/http-add-on) for more details and to learn how and why you would use this project.
+
+| 🚧 **Project status: beta** 🚧|
+|---------------------------------------------|
+| ⚠ The HTTP add-on currently is in [beta](https://github.com/kedacore/http-add-on/releases/tag/v0.2.0). We can't yet recommend it for production usage because we are still developing and testing it. It may have "rough edges" including missing documentation, bugs and other issues. It is currently provided as-is without support.
+

--- a/artifacthub/add-ons-http/0.2.0/artifacthub-pkg.yml
+++ b/artifacthub/add-ons-http/0.2.0/artifacthub-pkg.yml
@@ -1,0 +1,51 @@
+# Artifact Hub package metadata file
+# https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-pkg.yml
+version: 0.2.0
+name: keda-add-ons-http
+displayName: KEDA HTTP
+createdAt: 2021-06-24T10:00:00Z
+description: Event-based autoscaler for HTTP workloads on Kubernetes
+license: Apache-2.0
+homeURL: https://github.com/kedacore/http-add-on
+keywords:
+  - keda
+  - http
+  - autoscaling
+links:
+  - name: GitHub
+    url: https://github.com/kedacore/http-add-on
+  - name: Helm Registry
+    url: https://github.com/kedacore/charts
+changes:
+  - kind: changed
+    description: This is the second beta release of the KEDA HTTP Addon. This release features a large internal change to enable multi-tenancy. With this change, you'll see a single external scaler pod and a single fleet (1 or more pods) of interceptor pods. These components are now designed to serve all of your applications.
+    links:
+      - name: GitHub release
+        url: https://github.com/kedacore/http-add-on/releases/tag/0.2.0
+  - kind: changed
+    description: This is the first beta version of the KEDA HTTP Add-on! It's been a while since our last release, which was 0.0.1. Since then, we've made big improvements to nearly every area of this project.
+    links:
+      - name: GitHub Release
+        url: https://github.com/kedacore/http-add-on/releases/tag/0.1.0
+provider:
+  name: KEDA
+recommendations:
+  - url: https://artifacthub.io/packages/helm/kedacore/keda
+install: |
+  You'll find abridged installation instructions for Helm here.
+  To find detailed instructions, please see:
+  https://github.com/kedacore/http-add-on/blob/main/docs/install.md
+
+  The KEDA HTTP Addon requires KEDA core to function. First,
+  ensure that your Helm repositories are properly configured:
+
+  $ helm repo add kedacore https://kedacore.github.io/charts
+  $ helm repo update
+
+  Next, install KEDA core:
+
+  $ helm install keda kedacore/keda --namespace <your namespace> --create-namespace
+
+  Finally, install the KEDA HTTP Addon:
+
+  $ helm install http-add-on kedacore/keda-add-ons-http --namespace <your namespace>


### PR DESCRIPTION
This PR adds an entry in artifact hub for the KEDA HTTP Addon version 0.2.0 release

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #11

cc/ @tomkerkhove 
