### PR TITLE
chore: add http-add-on v0.13.0 to artifact hub

### DIFF
--- a/artifacthub/add-ons-http/0.13.0/README.md
+++ b/artifacthub/add-ons-http/0.13.0/README.md
@@ -1,0 +1,10 @@
+<p align="center"><img src="https://github.com/kedacore/keda/raw/main/images/logos/keda-word-colour.png" width="300"/></p>
+
+<p style="font-size: 25px" align="center"><b>Kubernetes-based Event Driven Autoscaling - HTTP Add-On</b></p>
+<p style="font-size: 25px" align="center">
+
+The KEDA HTTP Add-on allows Kubernetes users to automatically scale their HTTP servers up and down (including to/from zero) based on incoming HTTP traffic. Please see our [use cases document](./docs/use_cases.md) to learn more about how and why you would use this project.
+
+| 🚧 **Project status: beta** 🚧|
+|---------------------------------------------|
+| :loudspeaker: **KEDA is actively relying on community contributions to help grow & maintain the add-on. The KEDA maintainers are assisting the community to evolve the add-on but not directly responsible for it.** Feel free to [open a new discussion](https://github.com/kedacore/http-add-on/discussions/new/choose) in case of questions.<br/><br/>⚠ The HTTP Add-on currently is in [beta](https://github.com/kedacore/http-add-on/releases/latest). We can't yet recommend it for production usage because we are still developing and testing it. It may have "rough edges" including missing documentation, bugs and other issues. It is currently provided as-is without support. |

--- a/artifacthub/add-ons-http/0.13.0/artifacthub-pkg.yml
+++ b/artifacthub/add-ons-http/0.13.0/artifacthub-pkg.yml
@@ -1,0 +1,46 @@
+# Artifact Hub package metadata file
+# https://github.com/artifacthub/hub/blob/master/docs/metadata/artifacthub-pkg.yml
+version: 0.13.0
+name: keda-add-ons-http
+displayName: KEDA HTTP
+createdAt: 2026-03-23T12:31:45Z
+description: Event-based autoscaler for HTTP workloads on Kubernetes
+license: Apache-2.0
+homeURL: https://github.com/kedacore/http-add-on
+keywords:
+  - keda
+  - http
+  - autoscaling
+links:
+  - name: GitHub
+    url: https://github.com/kedacore/http-add-on
+  - name: Helm Registry
+    url: https://github.com/kedacore/charts
+changes:
+  - kind: changed
+    description: New release
+    links:
+      - name: GitHub release
+        url: https://github.com/kedacore/http-add-on/releases/tag/v0.13.0
+provider:
+  name: KEDA
+recommendations:
+  - url: https://artifacthub.io/packages/helm/kedacore/keda
+install: |
+  You'll find abridged installation instructions for Helm here.
+  To find detailed instructions, please see:
+  https://github.com/kedacore/http-add-on/blob/main/docs/install.md
+
+  The KEDA HTTP Addon requires KEDA core to function. First,
+  ensure that your Helm repositories are properly configured:
+
+  $ helm repo add kedacore https://kedacore.github.io/charts
+  $ helm repo update
+
+  Next, install KEDA core:
+
+  $ helm install keda kedacore/keda --namespace <your namespace> --create-namespace
+
+  Finally, install the KEDA HTTP Addon:
+
+  $ helm install http-add-on kedacore/keda-add-ons-http --version 0.13.0 --namespace <your namespace>


### PR DESCRIPTION
Adds http-add-on v0.13.0 to Artifact Hub

Related: https://github.com/kedacore/http-add-on/releases/tag/v0.13.0