### PR TITLE
Add LLM-inference (vLLM KV-cache + queue) external scaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ Explore external scalers built by the community.
 - ActiveMQ Artemis ([GitHub](https://github.com/balchua/artemis-ext-scaler))
 - Durable Tasks/Functions with Azure Storage ([Artifact Hub](https://artifacthub.io/packages/keda-scaler/wsugarman-keda-scalers/durabletask-azurestorage-scaler))
 - GitHub Runners ([GitHub](https://github.com/devjoes/github-runner-autoscaler))
+- LLM inference (vLLM KV-cache + request-queue saturation) ([GitHub](https://github.com/kornsour/keda-inference-scaler))


### PR DESCRIPTION
Adds a community external scaler to the list: an **inference-aware KEDA external scaler** for LLM serving (vLLM).

It scales on a **composite** signal — `max(queueDepth / threshold, kvCacheUtil / threshold)` — combining request-queue depth and KV-cache utilization in a single trigger, which the built-in single-query Prometheus scaler can't express. Written in Go (implements the external-scaler gRPC contract); ships a Dockerfile, unit tests, an example `ScaledObject`, and CI.

Source: https://github.com/kornsour/keda-inference-scaler